### PR TITLE
Enabled H2 console

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.h2.console.enabled=true


### PR DESCRIPTION
#### Description
Enabled H2 Database Console, so it's visible when going to `localhost:{port}/h2-console`.